### PR TITLE
Fix panic in `negative-cache` check if there are no resolver records

### DIFF
--- a/check_negative_cache.go
+++ b/check_negative_cache.go
@@ -8,7 +8,7 @@ var CheckNegativeCache = &Check{
 }
 
 func checkNegativeCache(config *Config, outputs *DigOutputs) (*CheckResult, error) {
-	if outputs.resolverNoRecurse.Status != "NOERROR" && outputs.resolverNoRecurse.Status != "NXDOMAIN" {
+	if len(outputs.resolverNoRecurse.Answers) == 0 || (outputs.resolverNoRecurse.Status != "NOERROR" && outputs.resolverNoRecurse.Status != "NXDOMAIN") {
 		return &CheckResult{
 			Status:  true,
 			Message: fmt.Sprintf("Resolver doesn't have any records cached"),


### PR DESCRIPTION
This is a suggested fix for issue #2 

Output (code does not panic now):

```
./dns-doctor d.idua.dev
FAILURE: no-record
  Details: No record found, using nameserver '162.159.11.180'
```